### PR TITLE
Suppress ruby 3.3 warning

### DIFF
--- a/activeadmin.gemspec
+++ b/activeadmin.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 3.0"
 
   s.add_dependency "arbre", "~> 2.0"
+  s.add_dependency "csv"
   s.add_dependency "formtastic", ">= 3.1"
   s.add_dependency "formtastic_i18n", ">= 0.4"
   s.add_dependency "inherited_resources", "~> 1.7"


### PR DESCRIPTION
```
/myapp/vendor/bundle/gems/zeitwerk-2.6.13/lib/zeitwerk/kernel.rb:34: warning: csv was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec. Also contact author of activeadmin-3.2.0 to add csv into its gemspec.
```

<!--

Thanks for contributing to ActiveAdmin!

You can find the instructions in our contributing guide: https://github.com/activeadmin/activeadmin/blob/master/CONTRIBUTING.md

Before submitting your PR make sure that:
* You wrote [good commit messages].
* The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* The PR description [includes keywords to automatically close issues] if it fixes an existing issue.
* Your feature branch is up-to-date with `master` (if not - rebase it), and does not include merge commits.
* Related commits are squashed together, and unrelated commits are separated.
* Your PR includes a regression test if it fixes a bug.

Before expecting a review for your PR make sure that all CI checks are passing, but feel free to ask for early feedback if you need guidance.

[good commit messages]: https://chris.beams.io/posts/git-commit/
[includes keywords to automatically close issues]: https://help.github.com/en/articles/closing-issues-using-keywords

-->
